### PR TITLE
modified query index for compatibility with pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 sudo: false
 cache: pip
 python:
-- '2.7'
-- '3.5'
 - '3.6'
 - '3.7'
 - '3.8'

--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -256,14 +256,28 @@ def yearplot(
         start = datetime.datetime(year, 1, 1).weekday()
         x0 = (int(first.strftime("%j")) + start - 1) // 7
         x1 = (int(last.strftime("%j")) + start - 1) // 7
-        P = [(x0, y0 + 1), (x0, 0), (x1, 0), (x1, y1),
-             (x1 + 1, y1), (x1 + 1, 7), (x0 + 1, 7), (x0 + 1, y0 + 1)]
+        P = [
+            (x0, y0 + 1),
+            (x0, 0),
+            (x1, 0),
+            (x1, y1),
+            (x1 + 1, y1),
+            (x1 + 1, 7),
+            (x0 + 1, 7),
+            (x0 + 1, y0 + 1),
+        ]
 
         xticks.append(x0 + (x1 - x0 + 1) / 2)
         labels.append(first.strftime("%b"))
         if monthly_border:
-            poly = Polygon(P, edgecolor="black", facecolor="None",
-                       linewidth=1, zorder=20, clip_on=False)
+            poly = Polygon(
+                P,
+                edgecolor="black",
+                facecolor="None",
+                linewidth=1,
+                zorder=20,
+                clip_on=False,
+            )
             ax.add_artist(poly)
 
     ax.set_xticks(xticks)
@@ -274,7 +288,6 @@ def yearplot(
     ax.set_yticklabels(
         [daylabels[i] for i in dayticks], rotation="horizontal", va="center"
     )
-
 
     return ax
 

--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -19,7 +19,7 @@ from distutils.version import StrictVersion
 from dateutil.relativedelta import relativedelta
 from matplotlib.patches import Polygon
 
-__version_info__ = ("0", "0", "8")
+__version_info__ = ("0", "0", "9")
 __date__ = "22 Nov 2018"
 
 

--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -178,7 +178,7 @@ def yearplot(
             "data": by_day,
             "fill": 1,
             "day": by_day.index.dayofweek,
-            "week": by_day.index.week,
+            "week": by_day.index.isocalendar().week,
         }
     )
 
@@ -235,7 +235,12 @@ def yearplot(
         dayticks = range(len(daylabels))[dayticks // 2 :: dayticks]
 
     ax.set_xlabel("")
-    ax.set_xticks([by_day.loc[datetime.date(year, i + 1, 15)].week for i in monthticks])
+    timestamps = []
+    for i in monthticks:
+        date = str(datetime.date(year, i + 1, 15))
+        timestamp = datetime.datetime.strptime(date, '%Y-%m-%d')
+        timestamps.append(timestamp)
+    ax.set_xticks(by_day.loc[timestamps].week)
     ax.set_xticklabels([monthlabels[i] for i in monthticks], ha="center")
 
     ax.set_ylabel("")

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+numpy>=1.16.5 
 matplotlib>=2.0.0
 numpydoc
 Sphinx<=1.8.2


### PR DESCRIPTION

In this fix 2 issues are addressed:

1. Tests failing on current version (216fc6be, tag: v0.0.8): `../calmap/__init__.py:238 KeyError`
Details please see pytest log: https://pastebin.ubuntu.com/p/TQt7WRFzpc/

2. Future warning
current_projects/calmap/calmap/__init__.py:181: FutureWarning: weekofyear and week have been deprecated, please use DatetimeIndex.isocalendar().week instead, which returns a Series.  To exactly reproduce the behavior of week and weekofyear and return an Index, you may call pd.Int64Index(idx.isocalendar().week)
    "week": by_day.index.week,

My running environment:
- Python 3.8.3
- Pandas 1.1.0

Discussions and comments are very welcome!