### PR TITLE
CI house cleaning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 sudo: false
 cache: pip
 python:
-- '2.7'
-- '3.5'
 - '3.6'
 - '3.7'
 - '3.8'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+numpy>=1.16.5 
 matplotlib>=2.0.0
 numpydoc
 Sphinx<=1.8.2


### PR DESCRIPTION
When people were working on this pull request https://github.com/MarvinT/calmap/pull/9 , we have consensus to stop supporting Python 2.7 and 3.5[*]. Besides, we were also aware of numpy version compatibility issue of Travis CI run for Python 3.7. This pull request will:

- Stop support of Python 2.7 and 3.5.
- Pass the Python 3.7 CI error.

Please note the pull request is on top of the work of https://github.com/MarvinT/calmap/pull/9 , so the code base of https://github.com/MarvinT/calmap/pull/9 is prerequisite.


[*] Python end of life date for your reference https://endoflife.date/python 


# Steps to Test This Pull Request
1. Pull the prerequisite code base https://github.com/MarvinT/calmap/pull/9
2. Trigger the corresponding Travis CI.


# Expected Results
If you have run the Travis CI on top of the target pull request https://github.com/MarvinT/calmap/pull/9 , you will get this result https://travis-ci.com/github/tai271828/calmap/builds/219757231 . CI will pass for Python 3.7 and above. Python 2.7 and 3.5 are disabled and removed, so they won't show up on the Travis CI dashboard.
