### PR TITLE
Render README.md from Markdown on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     version=distmeta["__version_info__"],
     description="Calendar heatmaps from Pandas time series data",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author=distmeta["__author__"],
     author_email=distmeta["__contact__"],
     url=distmeta["__homepage__"],


### PR DESCRIPTION
https://pypi.org/project/calmap/ shows the README.md text but doesn't render the Markdown:

![image](https://user-images.githubusercontent.com/1324225/153221868-90f5023d-c64b-41dc-a373-a7e7d883a9ad.png)

This can be fixed by adding `long_description_content_type="text/markdown",` to `setup.py`.

More info:

* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/
* https://github.com/di/markdown-description-example
