### PR TITLE
Use keyword arguments for DataFrame.pivot

### DIFF
--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -199,11 +199,11 @@ def yearplot(
     )
 
     # Pivot data on day and week and mask NaN days. (we can also mask the days with 0 counts)
-    plot_data = by_day.pivot("day", "week", "data").values[::-1]
+    plot_data = by_day.pivot(index="day", columns="week", values="data").values[::-1]
     plot_data = np.ma.masked_where(np.isnan(plot_data), plot_data)
 
     # Do the same for all days of the year, not just those we have data for.
-    fill_data = by_day.pivot("day", "week", "fill").values[::-1]
+    fill_data = by_day.pivot(index="day", columns="week", values="fill").values[::-1]
     fill_data = np.ma.masked_where(np.isnan(fill_data), fill_data)
 
     # Draw background of heatmap for all days of the year with fillcolor.


### PR DESCRIPTION
The new version of pandas takes keyword-only arguments in DataFrame.pivot.

> DataFrame.pivot() takes 1 positional argument but 4 were given