### PR TITLE
Fix bug in daily agg and add support for pandas 2.0

### DIFF
--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -62,7 +62,7 @@ def yearplot(
     how : string
         Method for resampling data by day. If `None`, assume data is already
         sampled by day and don't resample. Otherwise, this is passed to Pandas
-        `Series.resample`.
+        `Series.resample` (pandas < 0.18) or `pandas.agg` (pandas >= 0.18).
     vmin : float
         Min Values to anchor the colormap. If `None`, min and max are used after
         resampling data by day.

--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -384,7 +384,7 @@ def calendarplot(
         by_day = data
     else:
         if _pandas_18:
-            by_day = data.resample("D").agg(how)
+            by_day = data.groupby(level=0).agg(how).squeeze()
         else:
             by_day = data.resample("D", how=how)
 

--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -19,7 +19,7 @@ from distutils.version import StrictVersion
 from dateutil.relativedelta import relativedelta
 from matplotlib.patches import Polygon
 
-__version_info__ = ("0", "0", "9")
+__version_info__ = ("0", "0", "10")
 __date__ = "22 Nov 2018"
 
 
@@ -148,7 +148,7 @@ def yearplot(
     else:
         # Sample by day.
         if _pandas_18:
-            by_day = data.resample("D").agg(how)
+            by_day = data.groupby(level=0).agg(how).squeeze()
         else:
             by_day = data.resample("D", how=how)
 
@@ -199,11 +199,11 @@ def yearplot(
     )
 
     # Pivot data on day and week and mask NaN days. (we can also mask the days with 0 counts)
-    plot_data = by_day.pivot("day", "week", "data").values[::-1]
+    plot_data = by_day.pivot(index="day", columns="week", values="data").values[::-1]
     plot_data = np.ma.masked_where(np.isnan(plot_data), plot_data)
 
     # Do the same for all days of the year, not just those we have data for.
-    fill_data = by_day.pivot("day", "week", "fill").values[::-1]
+    fill_data = by_day.pivot(index="day", columns="week", values="fill").values[::-1]
     fill_data = np.ma.masked_where(np.isnan(fill_data), fill_data)
 
     # Draw background of heatmap for all days of the year with fillcolor.


### PR DESCRIPTION
The arguments to pandas [pivot](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.pivot.html) seem to have changed in pandas 2.0 which gives an error when you try to plot:

```
TypeError: DataFrame.pivot() takes 1 positional argument but 4 were given
```

While testing these changes, I also noticed that pandas resample filled missing days with 0 instead of NaN. Using groupby instead of resample seems to fix this.

All tests passed (with a couple of warnings), and the code snippet returned a plot that I expect.

I'm using Python 3.10, pandas 2.0, matplotlib 3.7.1, and numpy 1.24.2.

Edit: the pandas support is a duplicate of #14, my bad