### PR TITLE
Test and build docs on GitHub Actions

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,39 @@
+name: Docs
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+          allow-prereleases: true
+          cache: pip
+          cache-dependency-path: |
+            setup.py
+            doc/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -r doc/requirements.txt
+          python -m pip install -e .
+
+      - name: Build documentation
+        run: |
+          make -C doc html
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: doc/.build/html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: pip
+          cache-dependency-path: |
+            setup.py
+            tests/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -r tests/requirements.txt
+          python -m pip install -e .
+
+      - name: Test
+        run: |
+          pytest --cov=calmap --cov=tests

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 build
 dist
 .cache
+.coverage
 *.egg-info
 .sonarlint

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ------------------------------------------------
 [![PyPI version](https://badge.fury.io/py/calmap.svg)](https://badge.fury.io/py/calmap)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/calmap.svg)
-[![Build Status](https://travis-ci.com/MarvinT/calmap.svg?branch=master)](https://travis-ci.com/MarvinT/calmap)
+[![GitHub Actions status](https://github.com/MarvinT/calmap/workflows/Test/badge.svg)](https://github.com/MarvinT/calmap/actions)
 [![Coverage Status](https://coveralls.io/repos/github/MarvinT/calmap/badge.svg?branch=master)](https://coveralls.io/github/MarvinT/calmap?branch=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -15,7 +15,7 @@ from matplotlib.colors import ColorConverter, ListedColormap
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from distutils.version import StrictVersion
+from packaging import version
 from dateutil.relativedelta import relativedelta
 from matplotlib.patches import Polygon
 
@@ -28,7 +28,7 @@ __author__ = "Marvin Thielk; Martijn Vermaat"
 __contact__ = "marvin.thielk@gmail.com, martijn@vermaat.name"
 __homepage__ = "https://github.com/MarvinT/calmap"
 
-_pandas_18 = StrictVersion(pd.__version__) >= StrictVersion("0.18")
+_pandas_18 = version.parse(pd.__version__) >= version.parse("0.18")
 
 
 def yearplot(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-install_requires = ["matplotlib", "numpy", "pandas"]
+install_requires = ["matplotlib", "packaging", "numpy", "pandas"]
 
 try:
     with open("README.md") as readme:


### PR DESCRIPTION
For https://github.com/MarvinT/calmap/issues/18.
Fixes #22.

This PR adds workflows to run the tests and build the docs with GitHub Actions.

# Tests

It's only testing the upstream supported versions of Python: 3.8-3.11: https://devguide.python.org/versions/

I didn't add uploading of coverage to Coveralls. I usually use Codecov myself, so have left Coveralls out for later addition.

# Docs

The docs are built and uploaded as an "artifact" to GitHub Actions. This means you can download a zip of the built docs from the build summary tab.

(I usually use Read the Docs, and enable the PR build previews, so you get a hosted page for each PR.)

# Deploy

This PR does CI, not CD. I didn't attempt to add deploying to PyPI or upload of docs, but I recommend doing this later. PyPI's "Trusted Publishers" is an excellent choice along with the 'pypi-publish' GitHub Action:

* https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

I also didn't delete the old `.travis.yml` yet in case you need it for the deploy reference.

# Demo

* Test: https://github.com/hugovk/calmap/actions/runs/5723408597
* Docs: https://github.com/hugovk/calmap/actions/runs/5723408599
