### PR TITLE
Set long description as Markdown to fix README on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     version=distmeta["__version_info__"],
     description="Calendar heatmaps from Pandas time series data",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author=distmeta["__author__"],
     author_email=distmeta["__contact__"],
     url=distmeta["__homepage__"],


### PR DESCRIPTION
Re: https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/

This will render the Markdown properly on PyPI.

Right now it's like this: https://pypi.org/project/calmap/

<img width="831" alt="image" src="https://github.com/MarvinT/calmap/assets/1324225/1c175f84-3aa7-456d-9d78-231528794e09">
