### PR TITLE
Drop support for EOL Python <= 3.7

### DIFF
--- a/calmap/__init__.py
+++ b/calmap/__init__.py
@@ -6,8 +6,6 @@ similar to GitHub's contributions calendar.
 """
 
 
-from __future__ import unicode_literals
-
 import calendar
 import datetime
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Calmap documentation build configuration file, created by
 # sphinx-quickstart on Thu Nov 26 16:51:51 2015.
 #
@@ -59,8 +57,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Calmap"
-copyright = u"2015, %s" % calmap.__author__
+project = "Calmap"
+copyright = "2015, %s" % calmap.__author__
 author = calmap.__author__
 
 # The version info for the project you're documenting, acts as replacement for
@@ -236,7 +234,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "Calmap.tex", u"Calmap Documentation", u"Martijn Vermaat", "manual")
+    (master_doc, "Calmap.tex", "Calmap Documentation", "Martijn Vermaat", "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -264,7 +262,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "calmap", u"Calmap Documentation", [author], 1)]
+man_pages = [(master_doc, "calmap", "Calmap Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -279,7 +277,7 @@ texinfo_documents = [
     (
         master_doc,
         "Calmap",
-        u"Calmap Documentation",
+        "Calmap Documentation",
         author,
         "Calmap",
         "One line description of project.",

--- a/doc/sphinxext/plot_directive.py
+++ b/doc/sphinxext/plot_directive.py
@@ -131,9 +131,6 @@ The plot directive has the following configuration options:
         Provide a customized template for preparing restructured text.
 """
 
-import six
-from six.moves import xrange
-
 import sys
 import os
 import shutil

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 import os
 from setuptools import setup
 
-install_requires = ["matplotlib", "numpy", "pandas"]
-
 try:
     with open("README.md") as readme:
         long_description = readme.read()
@@ -36,7 +34,8 @@ setup(
     license="MIT License",
     platforms=["any"],
     packages=["calmap"],
-    install_requires=install_requires,
+    install_requires=["matplotlib", "numpy", "pandas"],
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -44,9 +43,10 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 try:
     with open("README.md") as readme:
         long_description = readme.read()
-except IOError:
+except OSError:
     long_description = "See https://pypi.python.org/pypi/calmap"
 
 # This is quite the hack, but we don't want to import our package from here

--- a/tests/test_calmap.py
+++ b/tests/test_calmap.py
@@ -3,7 +3,6 @@ Tests for calmap.
 """
 
 
-from __future__ import unicode_literals
 
 import numpy as np
 


### PR DESCRIPTION
Python 3.8 is the oldest supported: http://devguide.python.org/versions/

Also modernise syntax with https://github.com/asottile/pyupgrade.